### PR TITLE
Adding get prices endpoint method

### DIFF
--- a/src/rest_api.rs
+++ b/src/rest_api.rs
@@ -545,4 +545,31 @@ impl RestApi {
 
         Ok((headers, working_orders))
     }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    // PRICES
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    pub async fn prices_get(
+        &self,
+        epic: &str,
+        body: PricesGetRequest,
+    ) -> Result<(Value, PricesGetResponse), Box<dyn Error>> {
+        // Validate the body.
+        body.validate()?;
+
+        let url = format!("prices/{}", epic);
+
+        // Send the request to the REST client.
+        let (header_map, response_value) = self.client.get(url, Some(3), &Some(body)).await?;
+
+        // Convert header_map to json.
+        let headers: Value = headers_to_json(&header_map)?;
+        // Deserialize the response_value to WorkingOrdersPutResponse.
+        let prices = PricesGetResponse::from_value(&response_value)?;
+
+        Ok((headers, prices))
+    }
 }

--- a/src/rest_models.rs
+++ b/src/rest_models.rs
@@ -2698,3 +2698,42 @@ pub enum WorkingOrderTimeInForce {
     /// Good until specified date.
     GoodTillDate,
 }
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PricesGetRequest {
+    pub resolution: Option<Resolution>,
+    pub from: Option<NaiveDateTime>,
+    pub to: Option<NaiveDateTime>,
+    pub max: Option<u32>,
+    pub page_size: Option<u32>,
+    pub page_number: Option<u32>,
+}
+
+impl ValidateRequest for PricesGetRequest {
+    fn validate(&self) -> Result<(), Box<dyn Error>> {
+
+        match (self.from, self.to) {
+            (Some(from), Some(to)) => {
+                if to < from {
+                    return Err(Box::new(ApiError {
+                        message: "End date cannot be before start date".to_string(),
+                    }));
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PricesGetResponse {
+    pub metadata: PriceMetadata,
+    pub instrument_type: InstrumentType,
+    pub prices: Vec<Price>
+}
+
+impl ValidateResponse for PricesGetResponse {}

--- a/tests/rest_api_integration_tests.rs
+++ b/tests/rest_api_integration_tests.rs
@@ -1121,3 +1121,33 @@ async fn zzz_session_delete_works() {
 
     sleep();
 }
+
+/// Force this test to run last by using zzz_ prefix to ensure the session
+/// is not deleted before running other tests.
+#[tokio::test]
+async fn prices_get_works() {
+    // Get the API instance.
+    let api = get_or_init_rest_api().await;
+
+    let response = match api.prices_get("IX.D.FTSE.IFM.IP", PricesGetRequest {
+        resolution: None,
+        from: None,
+        to: None,
+        max: None,
+        page_size: None,
+        page_number: None,
+    }).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("Error getting session details: {:?}", e);
+            panic!("Test failed due to error.");
+        }
+    };
+
+    println!(
+        "Response headers: {}",
+        serde_json::to_string_pretty(&response.0).unwrap()
+    );
+
+    sleep();
+}


### PR DESCRIPTION
Adding `prices/{epic}` endpoint for getting historical prices for an instrument